### PR TITLE
Mod, Size and Module Filters are now working in ksp 0.90

### DIFF
--- a/GameData/SimplePartOrganizer/Source/PartOrganizer.cs
+++ b/GameData/SimplePartOrganizer/Source/PartOrganizer.cs
@@ -186,7 +186,7 @@ namespace PartOrganizer
                 GUI.skin = HighLogic.Skin;
          
             // we only want the sort & filter buttons if the parts panel is showing
-            if (EditorLogic.fetch.editorScreen != EditorLogic.EditorScreen.Parts)
+            if (EditorLogic.fetch.editorScreen != EditorScreen.Parts)
                 return;
 
             if (GUI.Button(new Rect(EditorPanels.Instance.partsPanelWidth + 20, Screen.height - 20, 60, 20), "Sort"))
@@ -492,9 +492,9 @@ namespace PartOrganizer
         //-------------------------------------------------------------------------------------------------------------------------------------------
         void DefineFilters()
         {
-            EditorPartList.Instance.ExcludeFilters.AddFilter(new EditorPartListFilter("Mod Filter", (part => !PartInFilteredButtons(part, modButtons, modHash))));
-            EditorPartList.Instance.ExcludeFilters.AddFilter(new EditorPartListFilter("Size Filter", (part => !PartInFilteredButtons(part, sizeButtons, sizeHash))));
-            EditorPartList.Instance.ExcludeFilters.AddFilter(new EditorPartListFilter("Modules Filter", (part => !PartInFilteredButtons(part, moduleButtons, moduleHash))));
+            EditorPartList.Instance.ExcludeFilters.AddFilter(new EditorPartListFilter<AvailablePart>("Mod Filter", (part => !PartInFilteredButtons(part, modButtons, modHash))));
+            EditorPartList.Instance.ExcludeFilters.AddFilter(new EditorPartListFilter<AvailablePart>("Size Filter", (part => !PartInFilteredButtons(part, sizeButtons, sizeHash))));
+            EditorPartList.Instance.ExcludeFilters.AddFilter(new EditorPartListFilter<AvailablePart>("Modules Filter", (part => !PartInFilteredButtons(part, moduleButtons, moduleHash))));
             EditorPartList.Instance.Refresh();
         }
 


### PR DESCRIPTION
Hey,

this pr makes the Filters compatible with ksp 0.90.
Tested on a stock and a 40+ mods install. works without problems so far.

I found no way to make the sortings work in ksp 0.90. I guess that the editor has a default sorting behaviour, that we can't change with a mod.
So i decided to just make a pr with the filters.

Greetings
Postremus
